### PR TITLE
Compatibility: Neovim doesn't have gui_running

### DIFF
--- a/autoload/ShowTrailingWhitespace/Color.vim
+++ b/autoload/ShowTrailingWhitespace/Color.vim
@@ -25,8 +25,10 @@ function! s:GetColorModes() abort
     if has('gui_running')
 	" Can't get back from GUI to terminal.
 	return ['gui']
-    elseif has('gui')
+    elseif has('gui') || has('nvim')
 	" This terminal may be upgraded to the GUI via :gui.
+	" Neovim uses cterm or gui depending on &termguicolors, and can be
+	" changed whenever the user wishes to.
 	return ['cterm', 'gui']
     else
 	" This terminal doesn't have GUI capabilities built in.


### PR DESCRIPTION
Neither has('gui_running') nor has('gui') return 1 in Neovim, even if a
gui is running.